### PR TITLE
Fixed space between node identifier and text that crashed mermaid.

### DIFF
--- a/src/Mermaid.Flowcharts/Node.cs
+++ b/src/Mermaid.Flowcharts/Node.cs
@@ -15,5 +15,5 @@ public readonly record struct Node
         => new(NodeIdentifier.FromString(identifier), MermaidUnicodeText.FromString(text));
 
     public override string ToString()
-        => $"{Id} [\"{Text}\"]";
+        => $"{Id}[\"{Text}\"]";
 }


### PR DESCRIPTION
Fixes #9 