### PR TITLE
Added node shape enum with text output tests.

### DIFF
--- a/src/Mermaid.Flowcharts/Nodes/Node.cs
+++ b/src/Mermaid.Flowcharts/Nodes/Node.cs
@@ -4,19 +4,59 @@ public readonly record struct Node : INode
 {
     public NodeIdentifier Id { get; }
     public MermaidUnicodeText Text { get; }
+    public NodeShape Shape { get; }
 
-    private Node(NodeIdentifier id, MermaidUnicodeText text)
+    private Node(NodeIdentifier id, MermaidUnicodeText text, NodeShape shape)
     {
         Id = id;
         Text = text;
+        Shape = shape;
     }
 
-    public static Node Create(string identifier, string text)
-        => new(NodeIdentifier.FromString(identifier), MermaidUnicodeText.FromString(text));
+    public static Node Create(string identifier, string text, NodeShape shape = NodeShape.Rectangle)
+        => new(NodeIdentifier.FromString(identifier), MermaidUnicodeText.FromString(text), shape);
 
     public override string ToString()
         => ToMermaidString();
 
     public string ToMermaidString(int indentations = 0, string indentationText = "  ")
-        => $"{indentationText.Repeat(indentations)}{Id}[\"{Text}\"]";
+    {
+        string shapeStart = Shape switch
+        {
+            NodeShape.RoundedEdges => "(",
+            NodeShape.Stadium => "([",
+            NodeShape.Subroutine => "[[",
+            NodeShape.Cylindrical => "[(",
+            NodeShape.Circle => "((",
+            NodeShape.DoubleCircle => "(((",
+            NodeShape.Asymmetric => ">",
+            NodeShape.Rhombus => "{",
+            NodeShape.Hexagon => "{{",
+            NodeShape.Parallelogram => "[/",
+            NodeShape.ParallelogramAlt => "[\\",
+            NodeShape.Trapezoid => "[/\\",
+            NodeShape.TrapezoidAlt => "[\\/",
+            _ => "[",
+        };
+
+        string shapeEnd = Shape switch
+        {
+            NodeShape.RoundedEdges => ")",
+            NodeShape.Stadium => "])",
+            NodeShape.Subroutine => "]]",
+            NodeShape.Cylindrical => ")]",
+            NodeShape.Circle => "))",
+            NodeShape.DoubleCircle => ")))",
+            NodeShape.Asymmetric => "]",
+            NodeShape.Rhombus => "}",
+            NodeShape.Hexagon => "}}",
+            NodeShape.Parallelogram => "/]",
+            NodeShape.ParallelogramAlt => "\\]",
+            NodeShape.Trapezoid => "/\\]",
+            NodeShape.TrapezoidAlt => "\\/]",
+            _ => "]",
+        };
+
+        return $"{indentationText.Repeat(indentations)}{Id}{shapeStart}\"{Text}\"{shapeEnd}";
+    }
 }

--- a/src/Mermaid.Flowcharts/Nodes/NodeShape.cs
+++ b/src/Mermaid.Flowcharts/Nodes/NodeShape.cs
@@ -1,0 +1,19 @@
+namespace Mermaid.Flowcharts.Nodes;
+
+public enum NodeShape
+{
+    Rectangle,
+    RoundedEdges,
+    Stadium,
+    Subroutine,
+    Cylindrical,
+    Circle,
+    DoubleCircle,
+    Asymmetric,
+    Rhombus,
+    Hexagon,
+    Parallelogram,
+    ParallelogramAlt,
+    Trapezoid,
+    TrapezoidAlt
+} 

--- a/tests/Mermaid.Flowcharts.Tests/NodeTests.cs
+++ b/tests/Mermaid.Flowcharts.Tests/NodeTests.cs
@@ -5,12 +5,24 @@ namespace Mermaid.Flowcharts.Tests;
 public class NodeTests
 {
     [Theory]
-    [InlineData("a", "b", "a[\"b\"]")]
-    [InlineData("A.B", "あ", "A.B[\"あ\"]")]
-    public void NodeToMermaidString_ShouldBeRectangular_ByDefault(string identifier, string text, string expected)
+    [InlineData("a", "b", NodeShape.Rectangle, "a[\"b\"]")]
+    [InlineData("a", "b", NodeShape.RoundedEdges, "a(\"b\")")]
+    [InlineData("a", "b", NodeShape.Stadium, "a([\"b\"])")]
+    [InlineData("a", "b", NodeShape.Subroutine, "a[[\"b\"]]")]
+    [InlineData("a", "b", NodeShape.Cylindrical, "a[(\"b\")]")]
+    [InlineData("a", "b", NodeShape.Circle, "a((\"b\"))")]
+    [InlineData("a", "b", NodeShape.DoubleCircle, "a(((\"b\")))")]
+    [InlineData("a", "b", NodeShape.Asymmetric, "a>\"b\"]")]
+    [InlineData("a", "b", NodeShape.Rhombus, "a{\"b\"}")]
+    [InlineData("a", "b", NodeShape.Hexagon, "a{{\"b\"}}")]
+    [InlineData("a", "b", NodeShape.Parallelogram, "a[/\"b\"/]")]
+    [InlineData("a", "b", NodeShape.ParallelogramAlt, "a[\\\"b\"\\]")]
+    [InlineData("a", "b", NodeShape.Trapezoid, "a[/\\\"b\"/\\]")]
+    [InlineData("a", "b", NodeShape.TrapezoidAlt, "a[\\/\"b\"\\/]")]
+    public void NodeToMermaidString_ShouldRenderCorrectShape(string identifier, string text, NodeShape shape, string expected)
     {
         // Arrange
-        Node node = Node.Create(identifier, text);
+        Node node = Node.Create(identifier, text, shape);
 
         // Act
         string nodeString = node.ToMermaidString();


### PR DESCRIPTION
Added enum to support the required node shapes. Node creation is backwards compatible, rectangle is still the default. Closes #23