### PR TITLE
Changed the way duplicate nodes are handled

### DIFF
--- a/src/Mermaid.Flowcharts/Flowchart.cs
+++ b/src/Mermaid.Flowcharts/Flowchart.cs
@@ -25,8 +25,8 @@ public class Flowchart : IMermaidPrintable
 
     public Flowchart AddNode(INode node)
     {
-        if (ContainsNode(node) || ContainsNodeNested(node)) return this;
-
+        if (node is Node nd && Nodes.Any(nd.Equals)) return this;
+        
         _nodes.Add(node);
         return this;
     }
@@ -67,10 +67,4 @@ public class Flowchart : IMermaidPrintable
         }
         return flowchartStringBuilder.ToString();
     }
-
-    internal bool ContainsNode(INode node)
-        => Nodes.Any(n => n.Id == node.Id);
-
-    internal bool ContainsNodeNested(INode node)
-        => Subgraphs.Any(s => s.ContainsNode(node) || s.ContainsNodeNested(node));
 }

--- a/src/Mermaid.Flowcharts/Nodes/INode.cs
+++ b/src/Mermaid.Flowcharts/Nodes/INode.cs
@@ -4,3 +4,9 @@ public interface INode : IMermaidPrintable
 {
     public NodeIdentifier Id { get; }
 }
+
+public interface INode<TNode> : INode, IEquatable<TNode>
+    where TNode : INode<TNode>
+{
+    
+}

--- a/src/Mermaid.Flowcharts/Nodes/Node.cs
+++ b/src/Mermaid.Flowcharts/Nodes/Node.cs
@@ -1,6 +1,6 @@
 ﻿namespace Mermaid.Flowcharts.Nodes;
 
-public readonly record struct Node : INode
+public readonly record struct Node : INode<Node>
 {
     public NodeIdentifier Id { get; }
     public MermaidUnicodeText Text { get; }

--- a/src/Mermaid.Flowcharts/Subgraphs/Subgraph.cs
+++ b/src/Mermaid.Flowcharts/Subgraphs/Subgraph.cs
@@ -3,7 +3,7 @@ using Mermaid.Flowcharts.Nodes;
 
 namespace Mermaid.Flowcharts.Subgraphs;
 
-public readonly record struct Subgraph : INode
+public readonly record struct Subgraph : INode<Subgraph>
 {
     private readonly List<INode> _nodes = [];
 
@@ -20,6 +20,8 @@ public readonly record struct Subgraph : INode
 
     public Subgraph AddNode(INode node)
     {
+        if (node is Node nd && Nodes.Any(nd.Equals)) return this;
+        
         _nodes.Add(node);
         return this;
     }
@@ -44,10 +46,4 @@ public readonly record struct Subgraph : INode
         subgraphStringBuilder.Append($"{indent}end");
         return subgraphStringBuilder.ToString();
     }
-
-    internal bool ContainsNode(INode node)
-        => Nodes.Any(n => n.Id == node.Id);
-
-    internal bool ContainsNodeNested(INode node)
-        => Subgraphs.Any(s => s.ContainsNode(node) || s.ContainsNodeNested(node));
 }

--- a/tests/Mermaid.Flowcharts.Tests/FlowchartTests.cs
+++ b/tests/Mermaid.Flowcharts.Tests/FlowchartTests.cs
@@ -25,6 +25,26 @@ public class FlowchartTests
     }
 
     [Fact]
+    public void Flowchart_ShouldContainTwoNodes_WhenTryingToAddTwoNodesWithDuplicateIdsButDifferentValues()
+    {
+        // Arrange
+        Flowchart flowchart = new();
+        string randomId = Guid.NewGuid().ToString();
+        string randomText1 = Guid.NewGuid().ToString();
+        string randomText2 = Guid.NewGuid().ToString();
+        Node node1 = Node.Create(randomId, randomText1);
+        Node node2 = Node.Create(randomId, randomText2);
+
+        // Act
+        flowchart.AddNode(node1);
+        flowchart.AddNode(node2);
+
+        // Assert
+        Assert.NotEmpty(flowchart.Nodes);
+        Assert.Equal(2, flowchart.Nodes.Count());
+    }
+
+    [Fact]
     public void Flowchart_ShouldAddLinkNode_WhenNodesAreNotPartOfSubgraphs()
     {
         // Arrange

--- a/tests/Mermaid.Flowcharts.Tests/SubgraphTests.cs
+++ b/tests/Mermaid.Flowcharts.Tests/SubgraphTests.cs
@@ -5,6 +5,48 @@ namespace Mermaid.Flowcharts.Tests;
 
 public class SubgraphTests
 {
+    [Fact]
+    public void Subgraph_ShouldContainOneNode_WhenTryingToAddTheSameNodeMultipleTimes()
+    {
+        // Arrange
+        NodeIdentifier subgraphId = NodeIdentifier.FromString("SubgraphId");
+        MermaidUnicodeText subgraphTitle = MermaidUnicodeText.FromString("Subgraph Title");
+        Subgraph subgraph = new(subgraphId, subgraphTitle);
+        string randomId = Guid.NewGuid().ToString();
+        string randomText = Guid.NewGuid().ToString();
+        Node node = Node.Create(randomId, randomText);
+
+        // Act
+        subgraph.AddNode(node);
+        subgraph.AddNode(node);
+
+        // Assert
+        Assert.NotEmpty(subgraph.Nodes);
+        Assert.Single(subgraph.Nodes);
+    }
+
+    [Fact]
+    public void Subgraph_ShouldContainTwoNodes_WhenTryingToAddTwoNodesWithDuplicateIdsButDifferentValues()
+    {
+        // Arrange
+        NodeIdentifier subgraphId = NodeIdentifier.FromString("SubgraphId");
+        MermaidUnicodeText subgraphTitle = MermaidUnicodeText.FromString("Subgraph Title");
+        Subgraph subgraph = new(subgraphId, subgraphTitle);
+        string randomId = Guid.NewGuid().ToString();
+        string randomText1 = Guid.NewGuid().ToString();
+        string randomText2 = Guid.NewGuid().ToString();
+        Node node1 = Node.Create(randomId, randomText1);
+        Node node2 = Node.Create(randomId, randomText2);
+
+        // Act
+        subgraph.AddNode(node1);
+        subgraph.AddNode(node2);
+
+        // Assert
+        Assert.NotEmpty(subgraph.Nodes);
+        Assert.Equal(2, subgraph.Nodes.Count());
+    }
+
     [Theory]
     [InlineData(
         "a",


### PR DESCRIPTION
Nodes are now considered equal only when their Id, Text and Shape characteristics are the same. Multiple nodes with the same Id but different text or shape are considered different nodes. This reflects standard Mermaid behavior.

Changes:
- added generic `INode<TNode>` overload to implement type-specific equality
- added equality check when adding nodes to a flowchart or subgraph
- added tests to distinguish identical nodes and nodes with the same Id