### PR TITLE
61-fix-duplicate-node-adds-in-graph-and-subgraph-add-link

### DIFF
--- a/src/Mermaid.Flowcharts/Flowchart.cs
+++ b/src/Mermaid.Flowcharts/Flowchart.cs
@@ -16,6 +16,7 @@ public class Flowchart : IMermaidPrintable
     public IEnumerable<Node> Nodes => _nodes.OfType<Node>();
     public IEnumerable<Subgraph> Subgraphs => _nodes.OfType<Subgraph>();
     public IEnumerable<Link> Links => _links.AsReadOnly();
+    public IEnumerable<INode> AllNodeChildren => _nodes.Concat(Subgraphs.SelectMany(subgraph => subgraph.AllNodeChildren));
     public IEnumerable<Node> AllNodes => Nodes.Concat(Subgraphs.SelectMany(subgraph => subgraph.AllNodes));
     public IEnumerable<Link> AllLinks => Links.Concat(Subgraphs.SelectMany(subgraph => subgraph.AllLinks));
 
@@ -41,10 +42,12 @@ public class Flowchart : IMermaidPrintable
 
     public Flowchart AddLink(Link link)
     {
-        _links.Add(link);
-        AddNode(link.Source);
-        AddNode(link.Destination);
-        return this;
+        if (AllNodeChildren.Any(link.Source.Equals) && AllNodeChildren.Any(link.Destination.Equals))
+        {
+            _links.Add(link);
+            return this;
+        }
+        throw new InvalidOperationException("Cannot add link to flowchart: the source and the destination nodes should both be present within the flowchart.");
     }
 
     public override string ToString()

--- a/src/Mermaid.Flowcharts/Subgraphs/Subgraph.cs
+++ b/src/Mermaid.Flowcharts/Subgraphs/Subgraph.cs
@@ -16,6 +16,7 @@ public record Subgraph : INode<Subgraph>
     public IEnumerable<Node> Nodes => _nodes.OfType<Node>();
     public IEnumerable<Subgraph> Subgraphs => _nodes.OfType<Subgraph>();
     public IEnumerable<Link> Links => _links.AsReadOnly();
+    public IEnumerable<INode> AllNodeChildren => _nodes.Concat(Subgraphs.SelectMany(subgraph => subgraph._nodes));
     public IEnumerable<Node> AllNodes => Nodes.Concat(Subgraphs.SelectMany(subgraph => subgraph.AllNodes));
     public IEnumerable<Link> AllLinks => Links.Concat(Subgraphs.SelectMany(subgraph => subgraph.AllLinks));
 
@@ -50,6 +51,11 @@ public record Subgraph : INode<Subgraph>
 
     public Subgraph AddNode(INode node)
     {
+        if (Equals(node))
+        {
+            throw new ArgumentException("Cannot add subgraph as a node to itself.", nameof(node));
+        }
+
         if (node is Node nd && Nodes.Any(nd.Equals))
         {
             return this;
@@ -61,10 +67,12 @@ public record Subgraph : INode<Subgraph>
 
     public Subgraph AddLink(Link link)
     {
-        _links.Add(link);
-        AddNode(link.Source);
-        AddNode(link.Destination);
-        return this;
+        if (AllNodeChildren.Any(link.Source.Equals) && AllNodeChildren.Any(link.Destination.Equals))
+        {
+            _links.Add(link);
+            return this;
+        }
+        throw new InvalidOperationException("Cannot add link to subgraph: the source and the destination nodes should both be present within the subgraph.");
     }
 
     public override string ToString()

--- a/tests/Mermaid.Flowcharts.Tests/FlowchartTests.cs
+++ b/tests/Mermaid.Flowcharts.Tests/FlowchartTests.cs
@@ -58,7 +58,7 @@ public class FlowchartTests
             .AddNode(n1)
             .AddNode(n2)
             .AddLink(link);
-        
+
         // Assert
         Assert.NotEmpty(flowchart.AllNodes);
         Assert.Equal(2, flowchart.AllNodes.Count());
@@ -81,7 +81,7 @@ public class FlowchartTests
             .AddNode(sg1.AddNode(sg1Node))
             .AddNode(sg2.AddNode(sg2Node))
             .AddLink(link);
-        
+
         // Assert
         Assert.NotEmpty(flowchart.AllNodes);
         Assert.Equal(2, flowchart.AllNodes.Count());
@@ -102,7 +102,7 @@ public class FlowchartTests
             .AddNode(n)
             .AddNode(subgraph)
             .AddLink(link);
-        
+
         // Assert
         Assert.NotEmpty(flowchart.AllNodeChildren);
         Assert.Equal(2, flowchart.AllNodeChildren.Count());
@@ -729,7 +729,7 @@ public class FlowchartTests
                 )
             .AddLink(nToSgn)
             .AddLink(sgnToSsgn);
-        
+
         string expected =
         $"""
         flowchart TD
@@ -747,7 +747,7 @@ public class FlowchartTests
             sgn ---> ssgn
 
         """;
-        
+
         // Act
         string actual = flowchart.ToMermaidString(0, "    ");
 
@@ -779,7 +779,7 @@ public class FlowchartTests
                     .AddLink(ssgnToSgn)
                 )
             .AddLink(sgnToN);
-        
+
         string expected =
         $"""
         flowchart TD
@@ -798,7 +798,7 @@ public class FlowchartTests
             sgn ---> n
 
         """;
-        
+
         // Act
         string actual = flowchart.ToMermaidString(0, "    ");
 

--- a/tests/Mermaid.Flowcharts.Tests/SubgraphTests.cs
+++ b/tests/Mermaid.Flowcharts.Tests/SubgraphTests.cs
@@ -112,7 +112,7 @@ public class SubgraphTests
             .AddNode(n)
             .AddNode(subsubgraph)
             .AddLink(link);
-        
+
         // Assert
         Assert.NotEmpty(subgraph.AllNodeChildren);
         Assert.Equal(2, subgraph.AllNodeChildren.Count());


### PR DESCRIPTION
Tweaked Flowchart and Subgraph tests to constrain adding links. Links can now only be added within the scope of the callee, and both source and destination nodes must exist within the flowchart or subgraph before adding the link containing them.